### PR TITLE
Exclude hadoop-core from oozie-client dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -803,6 +803,10 @@
                         <artifactId>hadoop-auth</artifactId>
                     </exclusion>
                     <exclusion>
+                        <groupId>org.apache.hadoop</groupId>
+                        <artifactId>hadoop-core</artifactId>
+                    </exclusion>
+                    <exclusion>
                         <groupId>org.apache.activemq</groupId>
                         <artifactId>activemq-client</artifactId>
                     </exclusion>


### PR DESCRIPTION
Add hadoop-core exclusion in pom.xml under oozie-client dependency. It excludes hadoop-core dependency being pulled from oozie-client . Resolves #3 
